### PR TITLE
Fix navbar margin issue on small screens

### DIFF
--- a/components/container.tsx
+++ b/components/container.tsx
@@ -1,5 +1,15 @@
-export default function Container({ children }: { children: React.ReactNode }) {
+export default function Container({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
   return (
-    <div className="mx-auto max-w-7xl px-6 md:px-12 xl:px-6">{children}</div>
+    <div
+      className={`mx-auto max-w-7xl px-6 md:px-12 xl:px-6 ${className || ""}`}
+    >
+      {children}
+    </div>
   )
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -39,13 +39,13 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false)
 
   const toggleMenu = () => {
-    setIsOpen((currentState) => !currentState)
+    setIsOpen(!isOpen)
   }
 
   return (
     <nav className="z-10 mt-5 w-full border-b border-black/5 dark:border-white/5 lg:border-transparent">
-      <Container>
-        <div className="relative flex flex-wrap items-center justify-between gap-6 py-3 md:gap-0 md:py-4">
+      <Container className="md:!px-6">
+        <div className="relative flex flex-wrap items-center justify-between gap-6 py-3 md:gap-0">
           <div className="relative z-20 flex w-full justify-between md:px-0 lg:w-max">
             {/* Logo */}
             <Link

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -39,7 +39,7 @@ export default function Header() {
   const [isOpen, setIsOpen] = useState(false)
 
   const toggleMenu = () => {
-    setIsOpen(!isOpen)
+    setIsOpen((currentState) => !currentState)
   }
 
   return (
@@ -51,7 +51,7 @@ export default function Header() {
             <Link
               href="/"
               aria-label="logo"
-              className="flex items-center space-x-2"
+              className="flex items-center justify-center space-x-2"
             >
               <Image
                 unoptimized
@@ -115,7 +115,7 @@ export default function Header() {
           <Link
             href={link.to}
             onClick={toggleMenu}
-            className={`block w-full py-2 text-right font-medium transition hover:text-primary dark:hover:text-white md:px-4 ${path === link.to && "font-semibold underline underline-offset-4"}`}
+            className={`block w-full mr-6 py-2 text-right font-medium transition hover:text-primary dark:hover:text-white md:px-4 ${path === link.to && "font-semibold underline underline-offset-4"}`}
           >
             <span>{link.label}</span>
           </Link>


### PR DESCRIPTION
Resolve the issue with the navbar margin on small screens, ensuring proper alignment and spacing for a better responsive design experience. This will involve adjusting the margin properties to ensure that the navbar displays correctly on devices with smaller screen widths. Fixes #6 

## Before:
![Screenshot 2024-12-05 181834](https://github.com/user-attachments/assets/7be986b4-f0fa-4c88-a32a-9254d9026e90)

## After:
![Screenshot 2024-12-05 182850](https://github.com/user-attachments/assets/9221bc79-10ef-4d9d-b5eb-ff9fce7b9a48)

## Update Video:

https://github.com/user-attachments/assets/c10ea151-551f-4f9a-a264-6819c4393628

