### PR TITLE
Fix: allow protocol card images to overflow on hover instead of being…

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -9,11 +9,11 @@ interface Props {
   link: string
 }
 
-const Card: React.FC<Props> = ({ index, image, title, description, link }) => {
+const Card: React.FC<Props> = ({ image, title, description, link }) => {
   return (
-    <Link href={link}>
+    <Link href={link} aria-label={title}>
       <div
-        className="group relative flex h-auto flex-col justify-evenly rounded-lg border border-zinc-200 p-6 shadow-xl transition hover:shadow-2xl"
+        className="group relative flex h-auto flex-col justify-evenly rounded-lg border border-zinc-200 p-6 shadow-xl transition hover:shadow-2xl hover:z-10 focus-visible:z-10"
       >
         {/* Image container — removed overflow-hidden so zoom can overflow */}
         <div className="relative h-fit rounded-md flex justify-center items-center">


### PR DESCRIPTION
When hovering over protocol images, they were getting clipped by card margins.

Changes made:
- Removed `overflow-hidden` from image container
- Adjusted hover scale to allow images to overflow
- Ensured responsive behavior remains intact

Fixes #16



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centered "Learn more" action on cards with hover and active effects.
  * Expanded image area behavior allowing intentional image overflow and stronger hover zoom.

* **Accessibility**
  * Improved link labeling on cards for better screen-reader support.

* **Style**
  * Enhanced card hover shadow transition for a more pronounced lift.
  * Minor spacing, alignment, border, and padding refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->