### PR TITLE
Fix protocol card image cropping on hover

### DIFF
--- a/components/card.tsx
+++ b/components/card.tsx
@@ -12,37 +12,36 @@ interface Props {
 const Card: React.FC<Props> = ({ index, image, title, description, link }) => {
   return (
     <Link href={link}>
-      <div
-        key={index}
-        className="group relative flex h-auto flex-col justify-evenly rounded-lg border border-zinc-200 p-6 shadow-xl"
-      >
-        <div className="relative h-fit overflow-hidden rounded-md">
-          <Image
-            src={image}
-            alt="Protocol Logo"
-            loading="lazy"
-            width="700"
-            height="700"
-            className="h-64 w-full object-contain transition duration-500 group-hover:scale-105"
-          />
-        </div>
-        <div className="relative mt-4 h-fit">
-          <h3 className="text-center  text-2xl font-semibold leading-6 tracking-tight text-gray-800">
-            {title}
-          </h3>
-          <p className="mb-6 mt-2 text-center text-black">
-            {description.split("\n").map((item, key) => {
-              return (
-                <span key={key}>
-                  {item}
-                  <br />
-                </span>
-              )
-            })}
-          </p>
-        </div>
-      </div>
-    </Link>
+  <div
+    key={index}
+    className="group relative flex h-auto flex-col justify-evenly rounded-lg border border-zinc-200 p-6 shadow-xl"
+  >
+    <div className="relative h-fit overflow-visible rounded-md">
+      <Image
+        src={image}
+        alt="Protocol Logo"
+        loading="lazy"
+        width="700"
+        height="700"
+        className="h-64 w-full object-contain transition duration-500 group-hover:scale-105"
+      />
+    </div>
+    <div className="relative mt-4 h-fit">
+      <h3 className="text-center text-2xl font-semibold leading-6 tracking-tight text-gray-800">
+        {title}
+      </h3>
+      <p className="mb-6 mt-2 text-center text-black">
+        {description.split("\n").map((item, key) => (
+          <span key={key}>
+            {item}
+            <br />
+          </span>
+        ))}
+      </p>
+    </div>
+  </div>
+</Link>
+
   )
 }
 


### PR DESCRIPTION
#Summary
Fixes protocol card hover behavior where images were cropped when scaled.

# Change
- Allowed image wrapper overflow so scaled images are not clipped on hover.

### Notes
I noticed existing PRs (#17, #19, #20) that address this issue.
This PR is submitted as part of a hackathon contribution and follows the same intended fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated Card component structure and element organization for improved layout consistency.
  * Enhanced image overflow handling for better visual presentation.
  * Refined styling with minor adjustments to ensure improved consistency across the component interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->