### PR TITLE
fix: center align social links in footer

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -108,7 +108,7 @@ const navigation = [
 export default function Footer() {
   return (
     <footer className="p-10">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-center">
         {/*
         <Image
           unoptimized


### PR DESCRIPTION
## Summary
Changed the social links container from `justify-between` to `justify-center` to center align the social links in the footer as requested in issue #39.

## Changes
- Updated `components/footer.tsx`: changed `justify-between` to `justify-center`

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Footer layout adjusted: social and navigation items are now centered horizontally within the footer rather than distributed across the full width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->